### PR TITLE
add newline before list in 'Send Group Operation' section

### DIFF
--- a/draft-xue-distributed-mls.md
+++ b/draft-xue-distributed-mls.md
@@ -151,6 +151,7 @@ of the other leaf nodes is not filled in. Thus DMLS comes with functional trade-
 ## Send Group Operation
 
 A DMLS Send Group operates in the following way:
+
   * The creator of the group, occupying leaf index 0, is the designated owner of the Send
     Group
   * Other members only accept messages from the owner


### PR DESCRIPTION
I think this will improve rendering in <https://datatracker.ietf.org/doc/html/draft-xue-distributed-mls-02#section-4.1-1>, which currently shows all list items on one line